### PR TITLE
Conditional enablement

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,14 +1,26 @@
 const std = @import("std");
 
+const ProfileMode = enum {
+    enabled,
+    time_only,
+    disabled,
+};
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
 
     const profiler = b.addModule("profiler", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
+    const enabled = b.option(ProfileMode, "profile_mode", "Whether and how to enable profiling") orelse ProfileMode.disabled;
+    const options = b.addOptions();
+    options.addOption(ProfileMode, "profile_mode", enabled);
+
+    profiler.addOptions("profiler_config", options);
 
     const example = b.addExecutable(.{
         .name = "example",

--- a/build.zig
+++ b/build.zig
@@ -16,9 +16,9 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    const enabled = b.option(ProfileMode, "profile_mode", "Whether and how to enable profiling") orelse ProfileMode.disabled;
+    const profile_mode = b.option(ProfileMode, "profile_mode", "Whether and how to enable profiling") orelse ProfileMode.disabled;
     const options = b.addOptions();
-    options.addOption(ProfileMode, "profile_mode", enabled);
+    options.addOption(ProfileMode, "profile_mode", profile_mode);
 
     profiler.addOptions("profiler_config", options);
 

--- a/build.zig
+++ b/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    const profile_mode = b.option(ProfileMode, "profile_mode", "Whether and how to enable profiling") orelse ProfileMode.disabled;
+    const profile_mode = b.option(ProfileMode, "profile_mode", "Whether to fully enable, fully disable, or only enable final start/stop timing of the profiler") orelse ProfileMode.disabled;
     const options = b.addOptions();
     options.addOption(ProfileMode, "profile_mode", profile_mode);
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const profiler_config = @import("profiler_config");
 
 const ZoneData = struct {
     tsc_inclusive: u64,
@@ -25,8 +26,11 @@ fn Profiler(comptime ZonesEnum: type) type {
         }
 
         pub fn printResults(self: *Self, print_time: bool) !void {
+            const enabled = profiler_config.profile_mode;
+
             const stdout = std.io.getStdOut().writer();
             const total_cycles: u64 = self.end_tsc -% self.start_tsc;
+            try stdout.print("\nMode {s}", .{@tagName(enabled)});
             try stdout.print("\nTotal cycles: {d}", .{total_cycles});
             for (self.anchors, 0..) |a, i| {
                 const anchor_tag: ZonesEnum = @enumFromInt(i);

--- a/src/root.zig
+++ b/src/root.zig
@@ -40,7 +40,6 @@ fn Profiler(comptime ZonesEnum: type) type {
                 else => {
                     const stdout = std.io.getStdOut().writer();
                     const total_cycles: u64 = self.end_tsc -% self.start_tsc;
-                    try stdout.print("\nMode {s}", .{@tagName(mode)});
                     try stdout.print("\nTotal cycles: {d}", .{total_cycles});
                     if (mode == .enabled) {
                         for (self.anchors, 0..) |a, i| {


### PR DESCRIPTION
Adds a build option to control how the profiler is enabled during compilation.

Here's the new option:
```
  -Dprofile_mode=[enum]        Whether to fully enable, fully disable, or only enable final start/stop timing of the profiler
                                 Supported Values:
                                   enabled
                                   time_only
                                   disabled
 ```

When `time_only` is used, only the startTiming and stopTiming cycle count difference will be recorded and displayed. Tagging of zones won't record any cycle counts. If the option isn't specified, it'll default to disabled.